### PR TITLE
Fix bug where latest version of call wouldn't store the meet link in the event data

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -2434,7 +2434,7 @@ async function handler(
 
   const metadata = videoCallUrl
     ? {
-        videoCallUrl: getVideoCallUrlFromCalEvent(evt),
+        videoCallUrl: getVideoCallUrlFromCalEvent(evt) || videoCallUrl,
       }
     : undefined;
   const webhookData = {


### PR DESCRIPTION
This was resulting in the meet link not showing up in platform, but after this fix it does
