### PR TITLE
ICS suppression

### DIFF
--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -220,7 +220,7 @@ export default class GoogleCalendarService implements Calendar {
         calendarId: selectedCalendar,
         requestBody: payload,
         conferenceDataVersion: 1,
-        sendUpdates: "all",
+        sendUpdates: "externalOnly",
       });
 
       if (event && event.data.id && event.data.hangoutLink) {
@@ -294,7 +294,7 @@ export default class GoogleCalendarService implements Calendar {
         calendarId: selectedCalendar,
         eventId: uid,
         sendNotifications: true,
-        sendUpdates: "all",
+        sendUpdates: "externalOnly",
         requestBody: payload,
         conferenceDataVersion: 1,
       });
@@ -349,7 +349,7 @@ export default class GoogleCalendarService implements Calendar {
         calendarId: selectedCalendar,
         eventId: uid,
         sendNotifications: false,
-        sendUpdates: "all",
+        sendUpdates: "none",
       });
       return event?.data;
     } catch (error) {

--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -349,7 +349,7 @@ export default class GoogleCalendarService implements Calendar {
         calendarId: selectedCalendar,
         eventId: uid,
         sendNotifications: false,
-        sendUpdates: "none",
+        sendUpdates: "externalOnly",
       });
       return event?.data;
     } catch (error) {

--- a/packages/emails/email-manager.ts
+++ b/packages/emails/email-manager.ts
@@ -101,7 +101,7 @@ export const sendScheduledEmails = async (
   await Promise.all(emailsToSend);
 };
 
-export const sendRescheduledEmails = async (calEvent: CalendarEvent, attendeeEmailDisabled?: boolean) => {
+export const sendRescheduledEmails = async (calEvent: CalendarEvent) => {
   const emailsToSend: Promise<unknown>[] = [];
 
   emailsToSend.push(sendEmail(() => new OrganizerRescheduledEmail({ calEvent })));
@@ -112,13 +112,11 @@ export const sendRescheduledEmails = async (calEvent: CalendarEvent, attendeeEma
     }
   }
 
-  if (!attendeeEmailDisabled) {
-    emailsToSend.push(
-      ...calEvent.attendees.map((attendee) => {
-        return sendEmail(() => new AttendeeRescheduledEmail(calEvent, attendee));
-      })
-    );
-  }
+  emailsToSend.push(
+    ...calEvent.attendees.map((attendee) => {
+      return sendEmail(() => new AttendeeRescheduledEmail(calEvent, attendee));
+    })
+  );
 
   await Promise.all(emailsToSend);
 };
@@ -194,8 +192,7 @@ export const sendDeclinedEmails = async (calEvent: CalendarEvent) => {
 
 export const sendCancelledEmails = async (
   calEvent: CalendarEvent,
-  eventNameObject: Pick<EventNameObjectType, "eventName">,
-  attendeeEmailDisabled?: boolean
+  eventNameObject: Pick<EventNameObjectType, "eventName">
 ) => {
   const emailsToSend: Promise<unknown>[] = [];
 
@@ -207,30 +204,28 @@ export const sendCancelledEmails = async (
     }
   }
 
-  if (!attendeeEmailDisabled) {
-    emailsToSend.push(
-      ...calEvent.attendees.map((attendee) => {
-        return sendEmail(
-          () =>
-            new AttendeeCancelledEmail(
-              {
-                ...calEvent,
-                title: getEventName({
-                  ...eventNameObject,
-                  t: attendee.language.translate,
-                  attendeeName: attendee.name,
-                  host: calEvent.organizer.name,
-                  eventType: calEvent.type,
-                  ...(calEvent.responses && { bookingFields: calEvent.responses }),
-                  ...(calEvent.location && { location: calEvent.location }),
-                }),
-              },
-              attendee
-            )
-        );
-      })
-    );
-  }
+  emailsToSend.push(
+    ...calEvent.attendees.map((attendee) => {
+      return sendEmail(
+        () =>
+          new AttendeeCancelledEmail(
+            {
+              ...calEvent,
+              title: getEventName({
+                ...eventNameObject,
+                t: attendee.language.translate,
+                attendeeName: attendee.name,
+                host: calEvent.organizer.name,
+                eventType: calEvent.type,
+                ...(calEvent.responses && { bookingFields: calEvent.responses }),
+                ...(calEvent.location && { location: calEvent.location }),
+              }),
+            },
+            attendee
+          )
+      );
+    })
+  );
 
   await Promise.all(emailsToSend);
 };

--- a/packages/emails/templates/attendee-location-change-email.ts
+++ b/packages/emails/templates/attendee-location-change-email.ts
@@ -4,10 +4,11 @@ import AttendeeScheduledEmail from "./attendee-scheduled-email";
 export default class AttendeeLocationChangeEmail extends AttendeeScheduledEmail {
   protected getNodeMailerPayload(): Record<string, unknown> {
     return {
-      icalEvent: {
-        filename: "event.ics",
-        content: this.getiCalEventAsString(),
-      },
+      // MENTO: Never send ical, let google calendar do it
+      //icalEvent: {
+      //  filename: "event.ics",
+      //  content: this.getiCalEventAsString(),
+      //},
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
       replyTo: this.calEvent.organizer.email,

--- a/packages/emails/templates/attendee-rescheduled-email.ts
+++ b/packages/emails/templates/attendee-rescheduled-email.ts
@@ -4,10 +4,11 @@ import AttendeeScheduledEmail from "./attendee-scheduled-email";
 export default class AttendeeRescheduledEmail extends AttendeeScheduledEmail {
   protected getNodeMailerPayload(): Record<string, unknown> {
     return {
-      icalEvent: {
-        filename: "event.ics",
-        content: this.getiCalEventAsString(),
-      },
+      // MENTO: Never send ical, let google calendar do it
+      //icalEvent: {
+      //  filename: "event.ics",
+      //  content: this.getiCalEventAsString(),
+      //},
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
       replyTo: [...this.calEvent.attendees.map(({ email }) => email), this.calEvent.organizer.email],

--- a/packages/emails/templates/attendee-scheduled-email.ts
+++ b/packages/emails/templates/attendee-scheduled-email.ts
@@ -88,11 +88,12 @@ export default class AttendeeScheduledEmail extends BaseEmail {
     this.getiCalEventAsString();
 
     return {
-      icalEvent: {
-        filename: "event.ics",
-        content: this.getiCalEventAsString(),
-        method: "REQUEST",
-      },
+      // MENTO: Never send ical, let google calendar do it
+      //icalEvent: {
+      //  filename: "event.ics",
+      //  content: this.getiCalEventAsString(),
+      //  method: "REQUEST",
+      //},
       to: `${this.attendee.name} <${this.attendee.email}>`,
       from: `${this.calEvent.organizer.name} <${this.getMailerOptions().from}>`,
       replyTo: [...this.calEvent.attendees.map(({ email }) => email), this.calEvent.organizer.email],

--- a/packages/emails/templates/attendee-was-requested-to-reschedule-email.ts
+++ b/packages/emails/templates/attendee-was-requested-to-reschedule-email.ts
@@ -20,10 +20,11 @@ export default class AttendeeWasRequestedToRescheduleEmail extends OrganizerSche
     const toAddresses = [this.calEvent.attendees[0].email];
 
     return {
-      icalEvent: {
-        filename: "event.ics",
-        content: this.getiCalEventAsString(),
-      },
+      // MENTO: Never send ical, let google calendar do it
+      //icalEvent: {
+      //  filename: "event.ics",
+      //  content: this.getiCalEventAsString(),
+      //},
       from: `${APP_NAME} <${this.getMailerOptions().from}>`,
       to: toAddresses.join(","),
       subject: `${this.t("requested_to_reschedule_subject_attendee", {

--- a/packages/emails/templates/organizer-location-change-email.ts
+++ b/packages/emails/templates/organizer-location-change-email.ts
@@ -8,10 +8,11 @@ export default class OrganizerLocationChangeEmail extends OrganizerScheduledEmai
     const toAddresses = [this.teamMember?.email || this.calEvent.organizer.email];
 
     return {
-      icalEvent: {
-        filename: "event.ics",
-        content: this.getiCalEventAsString(),
-      },
+      // MENTO never send ical event, let google do it
+      // icalEvent: {
+      //   filename: "event.ics",
+      //   content: this.getiCalEventAsString(),
+      // },
       from: `${APP_NAME} <${this.getMailerOptions().from}>`,
       to: toAddresses.join(","),
       replyTo: [this.calEvent.organizer.email, ...this.calEvent.attendees.map(({ email }) => email)],

--- a/packages/emails/templates/organizer-requested-to-reschedule-email.ts
+++ b/packages/emails/templates/organizer-requested-to-reschedule-email.ts
@@ -19,10 +19,11 @@ export default class OrganizerRequestedToRescheduleEmail extends OrganizerSchedu
     const toAddresses = [this.calEvent.organizer.email];
 
     return {
-      icalEvent: {
-        filename: "event.ics",
-        content: this.getiCalEventAsString(),
-      },
+      // MENTO: Never send ical event. Let google do it
+      // icalEvent: {
+      //   filename: "event.ics",
+      //   content: this.getiCalEventAsString(),
+      // },
       from: `${APP_NAME} <${this.getMailerOptions().from}>`,
       to: toAddresses.join(","),
       subject: `${this.t("rescheduled_event_type_subject", {

--- a/packages/emails/templates/organizer-rescheduled-email.ts
+++ b/packages/emails/templates/organizer-rescheduled-email.ts
@@ -8,10 +8,11 @@ export default class OrganizerRescheduledEmail extends OrganizerScheduledEmail {
     const toAddresses = [this.teamMember?.email || this.calEvent.organizer.email];
 
     return {
-      icalEvent: {
-        filename: "event.ics",
-        content: this.getiCalEventAsString(),
-      },
+      // MENTO: Never send ical event. Let google do it
+      //icalEvent: {
+      //  filename: "event.ics",
+      //  content: this.getiCalEventAsString(),
+      //},
       from: `${APP_NAME} <${this.getMailerOptions().from}>`,
       to: toAddresses.join(","),
       replyTo: [this.calEvent.organizer.email, ...this.calEvent.attendees.map(({ email }) => email)],

--- a/packages/emails/templates/organizer-scheduled-email.ts
+++ b/packages/emails/templates/organizer-scheduled-email.ts
@@ -75,10 +75,11 @@ export default class OrganizerScheduledEmail extends BaseEmail {
     const toAddresses = [this.teamMember?.email || this.calEvent.organizer.email];
 
     return {
-      icalEvent: {
-        filename: "event.ics",
-        content: this.getiCalEventAsString(),
-      },
+      // MENTO never send ical event. Let google do it.
+      //icalEvent: {
+      //  filename: "event.ics",
+      //  content: this.getiCalEventAsString(),
+      //},
       from: `${APP_NAME} <${this.getMailerOptions().from}>`,
       to: toAddresses.join(","),
       replyTo: [this.calEvent.organizer.email, ...this.calEvent.attendees.map(({ email }) => email)],

--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -649,8 +649,7 @@ async function handler(req: CustomRequest) {
     }
 
     // TODO: if emails fail try to requeue them
-    // MENTO always disable emails to attendees
-    await sendCancelledEmails(evt, { eventName: bookingToDelete?.eventType?.eventName }, true);
+    await sendCancelledEmails(evt, { eventName: bookingToDelete?.eventType?.eventName });
   } catch (error) {
     console.error("Error deleting event", error);
   }


### PR DESCRIPTION
Based on testing & conversation with Jacob, this implements this approach:

1. Strip all ICS files from emails
2. Always send cal emails, now without ICS
3. Always suppress google to google emails

As a result:
1. Outlook users will always get a duplicate email (but we're okay with that)
2. Google users will never get a duplicate email
3. Everyone’s calendars will be updated properly