### PR TITLE
Implement default period type and length for chemistry calls

### DIFF
--- a/apps/web/components/getting-started/steps-views/UserProfile.tsx
+++ b/apps/web/components/getting-started/steps-views/UserProfile.tsx
@@ -8,6 +8,7 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { md } from "@calcom/lib/markdownIt";
 import { telemetryEventTypes, useTelemetry } from "@calcom/lib/telemetry";
 import turndown from "@calcom/lib/turndownService";
+import { PeriodType } from "@calcom/prisma/enums";
 import { trpc } from "@calcom/trpc/react";
 import { Button, Editor, ImageUploader, Label, showToast } from "@calcom/ui";
 import { ArrowRight } from "@calcom/ui/components/icon";
@@ -127,6 +128,8 @@ const UserProfile = () => {
       afterEventBuffer: 15,
       minimumBookingNotice: 1440,
       slotInterval: 30,
+      periodType: PeriodType.ROLLING,
+      periodDays: 10,
     },
   ];
 


### PR DESCRIPTION
## What does this PR do?

Implement default for chemistry calls of only being open for the next 10 days. See https://team-mento.slack.com/archives/C04139KMDUZ/p1701821357333089 for context