### PR TITLE
Add default values for fields we made required but didn't put in form

### DIFF
--- a/packages/features/eventtypes/components/CreateEventTypeDialog.tsx
+++ b/packages/features/eventtypes/components/CreateEventTypeDialog.tsx
@@ -92,6 +92,8 @@ export default function CreateEventTypeDialog({
   const form = useForm<z.infer<typeof createEventTypeInput>>({
     defaultValues: {
       length: 15,
+      afterEventBuffer: 0,
+      minimumBookingNotice: 0,
     },
     resolver: zodResolver(createEventTypeInput),
   });


### PR DESCRIPTION
This fixes an issue we introduced 8 months back where users of our home-modified version of cal.com cannot directly create new events because the form validation (invisibly) complains about missing fields. The solution is to add the fields as defaults - there are other places where these fields are modified.