### PR TITLE
Update reschedule and cancel links to go through the platform

### DIFF
--- a/packages/lib/CalEventParser.ts
+++ b/packages/lib/CalEventParser.ts
@@ -160,27 +160,15 @@ export const getManageLink = (calEvent: CalendarEvent, t: TFunction) => {
   )}?changes=true`;
 };
 
-export const getCancelLink = (calEvent: CalendarEvent): string => {
-  // const cancelLink = new URL((calEvent.bookerUrl ?? WEBAPP_URL) + `/booking/${getUid(calEvent)}`);
-  // cancelLink.searchParams.append("cancel", "true");
-  // cancelLink.searchParams.append("allRemainingBookings", String(!!calEvent.recurringEvent));
-  // const seatReferenceUid = getSeatReferenceId(calEvent);
-  // if (seatReferenceUid) cancelLink.searchParams.append("seatReferenceUid", seatReferenceUid);
-  // return cancelLink.toString();
-  return `${WEBAPP_URL}/booking/${getUid(calEvent)}?cancel=true`;
-};
-
-export const getRescheduleLink = (calEvent: CalendarEvent): string => {
-  const Uid = getUid(calEvent);
-  const seatUid = getSeatReferenceId(calEvent);
-
-  return `${calEvent.bookerUrl ?? WEBAPP_URL}/reschedule/${seatUid ? seatUid : Uid}`;
-};
-
 const getMentoRedirectLink = (calEvent: CalendarEvent, action: string) => {
   const Uid = getUid(calEvent);
   return `${process.env.NEXT_PUBLIC_MENTO_WEB_URL}/sessions/external/${Uid}/${action}`;
 };
+
+export const getCancelLink = (calEvent: CalendarEvent): string => getMentoRedirectLink(calEvent, "cancel");
+
+export const getRescheduleLink = (calEvent: CalendarEvent): string =>
+  getMentoRedirectLink(calEvent, "reschedule");
 
 const getGrowthPlanLink = (calEvent: CalendarEvent) => getMentoRedirectLink(calEvent, "growth");
 


### PR DESCRIPTION
## What does this PR do?

Updates calendar links for cancel and reschedule to go through the Mento platform. Possible now that https://github.com/team-mento/frontend/pull/779 is merged.
