### PR TITLE
chore | move each env gh to each own action

### DIFF
--- a/.github/workflows/deploy-do-production.yml
+++ b/.github/workflows/deploy-do-production.yml
@@ -1,15 +1,14 @@
-name: ci
+name: deploy-to-digital-ocean-production
 
 on:
   push:
     branches:
-      - 'develop'
       - 'release'
 
 jobs:
   docker:
     runs-on: ubuntu-latest
-    environment: ${{ github.ref_name }}
+    environment: release
     steps:
       - uses: actions/checkout@v3
       - name: Make envfile
@@ -69,18 +68,8 @@ jobs:
           token: ${{ secrets.DO_TOKEN }}
       - name: Registry login
         run: doctl registry login
-      - name: Tag and push image to dev
-        if: github.ref_name == 'develop'
-        run: |
-          docker tag docker_calcom registry.digitalocean.com/mento/docker_calcom:dev
-          docker push registry.digitalocean.com/mento/docker_calcom:dev
-      - name: Tag and push image to stage
-        if: github.ref_name == 'develop'
-        run: |
-          docker tag docker_calcom registry.digitalocean.com/mento/docker_calcom:stage
-          docker push registry.digitalocean.com/mento/docker_calcom:stage
       - name: Tag and push image to prod
-        if: github.ref_name == 'release'
+        if: github.ref_name == 'release' # extra if just to be extra safe for prod
         run: |
           docker tag docker_calcom registry.digitalocean.com/mento/docker_calcom:latest
           docker push registry.digitalocean.com/mento/docker_calcom:latest

--- a/.github/workflows/deploy-do-stage.yml
+++ b/.github/workflows/deploy-do-stage.yml
@@ -1,4 +1,4 @@
-name: deploy-to-digital-ocean-dev
+name: deploy-to-digital-ocean-staging
 
 on:
   push:
@@ -8,7 +8,8 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
-    environment: dev
+    # this is stage, but it was named develop on gh for some reason and can't be modified
+    environment: develop
     steps:
       - uses: actions/checkout@v3
       - name: Make envfile
@@ -68,7 +69,7 @@ jobs:
           token: ${{ secrets.DO_TOKEN }}
       - name: Registry login
         run: doctl registry login
-      - name: Tag and push image to dev
+      - name: Tag and push image to stage
         run: |
-          docker tag docker_calcom registry.digitalocean.com/mento/docker_calcom:dev
-          docker push registry.digitalocean.com/mento/docker_calcom:dev
+          docker tag docker_calcom registry.digitalocean.com/mento/docker_calcom:stage
+          docker push registry.digitalocean.com/mento/docker_calcom:stage


### PR DESCRIPTION
this tries to mitigatte confusion with the environments in gh. It also allows for canceling workflows that you may not want to run when testing updates; eg: ship dev but not stage yet, which uses vercel anyway right now. Allows for better branching in the future.