### PR TITLE
Fix ability to schedule across the DST boundary

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "typescript.preferences.importModuleSpecifier": "non-relative",
   "spellright.language": ["en"],


### PR DESCRIPTION
Lordy I loath working in our (very old) version of Cal, but I have tested this locally to the best of my abilities and it appears to resolve the issue where scheduling across the daylight savings time boundary fails, and do so in a way that doesn't break existing functionality.